### PR TITLE
Update libpng and zlib versions

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -511,11 +511,11 @@ def tf_workspace(path_prefix="", tf_repo_name=""):
   tf_http_archive(
       name = "zlib_archive",
       urls = [
-          "https://mirror.bazel.build/zlib.net/zlib-1.2.8.tar.gz",
-          "http://zlib.net/fossils/zlib-1.2.8.tar.gz",
+      	   "https://storage.googleapis.com/mirror.tensorflow.org/zlib.net/zlib-1.2.11.tar.gz",
+      	   "http://zlib.net/fossils/zlib-1.2.11.tar.gz",
       ],
-      sha256 = "36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d",
-      strip_prefix = "zlib-1.2.8",
+      sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+      strip_prefix = "zlib-1.2.11",
       build_file = str(Label("//third_party:zlib.BUILD")),
   )
 

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -232,11 +232,10 @@ def tf_workspace(path_prefix="", tf_repo_name=""):
   tf_http_archive(
       name = "png_archive",
       urls = [
-          "https://mirror.bazel.build/github.com/glennrp/libpng/archive/v1.2.53.tar.gz",
-          "https://github.com/glennrp/libpng/archive/v1.2.53.tar.gz",
+          "https://github.com/glennrp/libpng/archive/v1.6.35.tar.gz",
       ],
-      sha256 = "716c59c7dfc808a4c368f8ada526932be72b2fcea11dd85dc9d88b1df1dfe9c2",
-      strip_prefix = "libpng-1.2.53",
+      sha256 = "",
+      strip_prefix = "libpng-1.6.35",
       build_file = str(Label("//third_party:png.BUILD")),
   )
 

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -232,10 +232,10 @@ def tf_workspace(path_prefix="", tf_repo_name=""):
   tf_http_archive(
       name = "png_archive",
       urls = [
-          "https://github.com/glennrp/libpng/archive/v1.6.35.tar.gz",
+          "https://github.com/glennrp/libpng/archive/v1.6.37.tar.gz",
       ],
       sha256 = "",
-      strip_prefix = "libpng-1.6.35",
+      strip_prefix = "libpng-1.6.37",
       build_file = str(Label("//third_party:png.BUILD")),
   )
 

--- a/third_party/png.BUILD
+++ b/third_party/png.BUILD
@@ -9,27 +9,62 @@ cc_library(
     name = "png",
     srcs = [
         "png.c",
+        "pngdebug.h",
         "pngerror.c",
         "pngget.c",
+        "pnginfo.h",
+        "pnglibconf.h",
         "pngmem.c",
         "pngpread.c",
+        "pngpriv.h",
         "pngread.c",
         "pngrio.c",
         "pngrtran.c",
         "pngrutil.c",
         "pngset.c",
+        "pngstruct.h",
         "pngtrans.c",
         "pngwio.c",
         "pngwrite.c",
         "pngwtran.c",
         "pngwutil.c",
-    ],
+    ] + select({
+        ":windows": [
+            "intel/intel_init.c",
+            "intel/filter_sse2_intrinsics.c",
+        ],
+        "@org_tensorflow//tensorflow:linux_ppc64le": [
+            "powerpc/powerpc_init.c",
+            "powerpc/filter_vsx_intrinsics.c",
+        ],
+        "//conditions:default": [
+        ],
+    }),
     hdrs = [
         "png.h",
         "pngconf.h",
     ],
+    copts = select({
+        ":windows": ["-DPNG_INTEL_SSE_OPT=1"],
+        "//conditions:default": [],
+    }),
     includes = ["."],
-    linkopts = ["-lm"],
+    linkopts = select({
+        ":windows": [],
+        "//conditions:default": ["-lm"],
+    }),
     visibility = ["//visibility:public"],
     deps = ["@zlib_archive//:zlib"],
+)
+
+genrule(
+    name = "snappy_stubs_public_h",
+    srcs = ["scripts/pnglibconf.h.prebuilt"],
+    outs = ["pnglibconf.h"],
+    cmd = "sed -e 's/PNG_ZLIB_VERNUM 0/PNG_ZLIB_VERNUM 0x12b0/' $< >$@",
+)
+
+config_setting(
+    name = "windows",
+    values = {"cpu": "x64_windows"},
 )


### PR DESCRIPTION
Fix related to this thread:
https://hypernews.cern.ch/HyperNews/CMS/get/sw-develtools/2646
needs cmsdist bump of libpng to 1.6.37 