### PR TITLE
Update to make grpc_plugin code gen work 

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -494,6 +494,7 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
             "https://storage.googleapis.com/mirror.tensorflow.org/github.com/grpc/grpc/archive/b54a5b338637f92bfcf4b0bc05e0f57a5fd8fadd.tar.gz",
             "https://github.com/grpc/grpc/archive/b54a5b338637f92bfcf4b0bc05e0f57a5fd8fadd.tar.gz",
         ],
+        patch_file = clean_dep("//third_party:grpc.generate_cc.bzl.patch"),
     )
 
     tf_http_archive(

--- a/third_party/grpc.generate_cc.bzl.patch
+++ b/third_party/grpc.generate_cc.bzl.patch
@@ -1,12 +1,12 @@
 diff --git a/bazel/generate_cc.bzl b/bazel/generate_cc.bzl
-index 484959e..d2dadbb 100644
+index 484959e..81d52fd 100644
 --- a/bazel/generate_cc.bzl
 +++ b/bazel/generate_cc.bzl
 @@ -140,6 +140,7 @@ def generate_cc_impl(ctx):
          outputs = out_files,
          executable = ctx.executable._protoc,
          arguments = arguments,
-+        use_default_shell_env = true,
++        use_default_shell_env = True,
      )
  
      return struct(files = depset(out_files))

--- a/third_party/grpc.generate_cc.bzl.patch
+++ b/third_party/grpc.generate_cc.bzl.patch
@@ -1,0 +1,12 @@
+diff --git a/bazel/generate_cc.bzl b/bazel/generate_cc.bzl
+index 484959e..d2dadbb 100644
+--- a/bazel/generate_cc.bzl
++++ b/bazel/generate_cc.bzl
+@@ -140,6 +140,7 @@ def generate_cc_impl(ctx):
+         outputs = out_files,
+         executable = ctx.executable._protoc,
+         arguments = arguments,
++        use_default_shell_env = true,
+     )
+ 
+     return struct(files = depset(out_files))


### PR DESCRIPTION
This patch to the downloaded gprc repo allows protoc to be called when it depends on LD_LIBRARY_PATH being set. For some reason it was unset when protoc was called in the grpc plugin gen step on a SLF7 machine at Fermilab. The same step has LD_LIBRARY_PATH set when running in the cmsBuild environment. This was the only fix the worked. I though I should pass it along.